### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 ######################################################################################## 
 
-FROM python:3-slim AS builder
+FROM python:3.7-slim AS builder
 
 # Create the directory and instruct Docker to operate
 # from there from now on
@@ -32,7 +32,7 @@ COPY . .
 # as defined below.
 #
 ########################################################################################
-FROM python:3-slim AS anon-user
+FROM python:3.7-slim AS anon-user
 RUN sed -i -r "/^(root|nobody)/!d" /etc/passwd /etc/shadow /etc/group \
     && sed -i -r 's#^(.*):[^:]*$#\1:/sbin/nologin#' /etc/passwd
 
@@ -44,7 +44,7 @@ RUN sed -i -r "/^(root|nobody)/!d" /etc/passwd /etc/shadow /etc/group \
 
 FROM gcr.io/distroless/python3
 COPY --from=builder /app /app
-COPY --from=builder /usr/local/lib/python3.8/site-packages /usr/local/lib/python3.8/site-packages
+COPY --from=builder /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages
 COPY --from=anon-user /etc/passwd /etc/shadow /etc/group /etc/
 
 USER nobody

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,67 @@
-FROM python:3-alpine
-# Set an environment variable with the directory
-# where we'll be running the app
-ENV APP /app
+########################################################################################
+#
+# This build stage builds the sources
+#
+######################################################################################## 
+
+FROM python:3-slim AS builder
+
 # Create the directory and instruct Docker to operate
 # from there from now on
-RUN mkdir $APP
-WORKDIR $APP
-EXPOSE 5000
+RUN mkdir /app
+WORKDIR /app
 # Copy the requirements file in order to install
 # Python dependencies
 COPY requirements.txt .
 # Install Python dependencies
 RUN pip install -r requirements.txt                             
-RUN apk update && apk add postgresql-dev gcc python3-dev musl-dev
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends postgresql gcc python3-dev python-psycopg2 libpq-dev
 RUN pip3 install psycopg2
-RUN apk add --no-cache --virtual .build-deps gcc libc-dev libxslt-dev && \
-    apk add --no-cache libxslt && \
-    pip install --no-cache-dir lxml>=3.5.0 && \
-    apk del .build-deps
+RUN pip install --no-cache-dir lxml>=3.5.0 
 RUN pip3 install PyLD
 RUN pip3 install validators
 RUN pip3 install -U flask-cors
 RUN pip3 install requests
 # We copy the rest of the codebase into the image
 COPY . .
+
+########################################################################################
+#
+# This build stage creates an anonymous user to be used with the distroless build
+# as defined below.
+#
+########################################################################################
+FROM python:3-slim AS anon-user
+RUN sed -i -r "/^(root|nobody)/!d" /etc/passwd /etc/shadow /etc/group \
+    && sed -i -r 's#^(.*):[^:]*$#\1:/sbin/nologin#' /etc/passwd
+
+########################################################################################
+#
+# This build stage creates a distroless image for production.
+#
+##############################################################################
+
+FROM gcr.io/distroless/python3
+COPY --from=builder /app /app
+COPY --from=builder /usr/local/lib/python3.8/site-packages /usr/local/lib/python3.8/site-packages
+COPY --from=anon-user /etc/passwd /etc/shadow /etc/group /etc/
+
+USER nobody
+WORKDIR /app
+# Set an environment variable with the directory
+# where we'll be running the app
+ENV APP /app
 ENV PYTHONPATH=$PWD:$PYTHONPATH
-#CMD python app.py 
+
+LABEL "maintainer"="Trigyn Technologies"
+LABEL "org.opencontainers.image.authors"="Ravishankar Jethani"
+LABEL "org.opencontainers.image.documentation"="https://github.com/Trigyn-Technologies/Mintaka/README.md"
+LABEL "org.opencontainers.image.vendor"="Trigyn-Technologies."
+LABEL "org.opencontainers.image.licenses"=""
+LABEL "org.opencontainers.image.title"="Mintaka"
+LABEL "org.opencontainers.image.description"="A FIWARE Generic Enabler to support the usage of NGSI-LD data in time-series databases and serve temporal APIs"
+LABEL "org.opencontainers.image.source"="https://github.com/Trigyn-Technologies/Mintaka"
+
+CMD ["app.py"]
+EXPOSE 5000


### PR DESCRIPTION
This sets up a distroless build for Mintaka.

This PR fixes several issues raised by [docker/docker-bench-security](https://github.com/docker/docker-bench-security)

- Add standard metadata build `LABEL` (see [opencontainers.org](https://github.com/opencontainers/opencontainers.org))
- Create two-stage build process  using a **Distroless** build:

     -    Remove [disto](https://medium.com/@dwdraju/distroless-is-for-security-if-not-for-size-6eac789f695f)
     -    Run as anonymous user


Note that the Docker image is no longer based on musl/alpine but must copy over dependencies before running - see [this](https://www.abhaybhargav.com/stories-of-my-experiments-with-distroless-containers/) as a python example.

I wouldn't propose you merge this directly, but you could use it as a basis for your own updates. I've created the `Dockerfile` blind as I'm not running Mintaka with Orion-LD to check that it runs